### PR TITLE
suggested change in position of downloadable formats

### DIFF
--- a/themes-book/opentextbook/page-cover-second-block.php
+++ b/themes-book/opentextbook/page-cover-second-block.php
@@ -1,4 +1,4 @@
-			<section class="second-block-wrap"> 
+			<section class="second-block-wrap">
 				<div class="second-block clearfix">
 						<div class="description-book-info">
 							<?php $metadata = pb_get_book_information();?>
@@ -8,11 +8,11 @@
 										$about_unlimited = pb_decode( $metadata['pb_about_unlimited'] );
 										$about_unlimited = preg_replace( '/<p[^>]*>(.*)<\/p[^>]*>/i', '$1', $about_unlimited ); // Make valid HTML by removing first <p> and last </p>
 										echo $about_unlimited; ?></p>
-								<?php endif; ?>	
-							<!-- if there is a custom copyright description -->		
+								<?php endif; ?>
+							<!-- if there is a custom copyright description -->
 							<?php if ( ! empty ($metadata['pb_custom_copyright'])) : ?>
 									<h2><?php _e('Copyright', 'pressbooks') ;?></h2>
-									<p><?php 
+									<p><?php
 										$custom_copyright = pb_decode( $metadata['pb_custom_copyright']);
 										$custom_copyright = preg_replace( '/<p[^>]*>(.*)<\/p[^>]*>/i', '$1', $custom_copyright );
 										echo $custom_copyright;?>
@@ -22,9 +22,9 @@
 								  <div id="twitter" data-url="<?php the_permalink(); ?>" data-text="Check out this great book on PressBooks." data-title="Tweet"></div>
 								  <div id="facebook" data-url="<?php the_permalink(); ?>" data-text="Check out this great book on PressBooks." data-title="Like"></div>
 								  <div id="googleplus" data-url="<?php the_permalink(); ?>" data-text="Check out this great book on PressBooks." data-title="+1"></div>
-							  </div>	
+							  </div>
 						</div>
-							
+
 								<?php	$args = $args = array(
 										    'post_type' => 'back-matter',
 										    'tax_query' => array(
@@ -35,10 +35,10 @@
 										        )
 										    )
 										); ?>
-			
-		      				
+
+
 								<div class="author-book-info">
-		      				
+
 		      						<?php $loop = new WP_Query( $args );
 											while ( $loop->have_posts() ) : $loop->the_post(); ?>
 										    <h4><a href="<?php the_permalink(); ?>"><?php the_title();?></a></h4>
@@ -46,48 +46,6 @@
 										    the_excerpt();
 										    echo '</div>';
 											endwhile; ?>
-								</div>	
-					<!-- display links to files -->
-					<?php
-					$files = \PBT\Utility\latest_exports();
-					$options = get_option( 'pbt_redistribute_settings' );
-					if ( is_array( $files ) && ( true == $options['latest_files_public'] ) ) {
-						echo '<div class="alt-formats">'
-						. '<h4>Alternate Formats</h4>'
-						. '<p>This book is also available for free; download in the following formats:</p>';
-
-						$dir = \PressBooks\Export\Export::getExportFolder();
-						foreach ( $files as $ext => $filename ) {
-							$file_extension = substr( strrchr( $ext, '.' ), 1 );
-							$pre_suffix = (false == strstr( $ext, '._3.epub' )) ? strstr( $ext, '._vanilla.xml') : strstr( $ext, '._3.epub' );
-
-							switch ( $file_extension ) {
-								case 'html':
-									$file_class = 'xhtml';
-									break;
-								case 'xml':
-									$file_class = ( false == $pre_suffix) ? 'wxr' : 'vanillawxr';
-									break;
-								case 'epub':
-									$file_class =  ( false  == $pre_suffix ) ? 'epub' : 'epub3';
-									break;
-								default:
-									$file_class = $file_extension;
-									break;
-							}
-
-							$filename = strstr( $filename, '.', true );
-
-							// rewrite rule
-							$url = "open/download?filename={$filename}&type={$file_class}";
-							echo '<link itemprop="bookFormat" href="http://schema.org/EBook">'
-								. '<a rel="nofollow" itemprop="offers" itemscope itemtype="http://schema.org/Offer" href="' . $url . '">'
-								. '<span class="export-file-icon small ' . $file_class . '" title="' . esc_attr( $filename ) . '"></span>'
-								. '<meta itemprop="price" content="$0.00"><link itemprop="availability" href="http://schema.org/InStock"></a>';
-						}
-						// end .alt-formats
-						echo "</div";
-					}
-					?>
+								</div>
 					</div><!-- end .secondary-block -->
-				</section> <!-- end .secondary-block --> 
+				</section> <!-- end .secondary-block -->

--- a/themes-book/opentextbook/page-cover-top-block.php
+++ b/themes-book/opentextbook/page-cover-top-block.php
@@ -1,5 +1,5 @@
 <section id="post-<?php the_ID(); ?>" <?php post_class( array( 'top-block', 'clearfix', 'home-post' ) ); ?>>
-	
+
 	<?php pb_get_links(false); ?>
 	<?php $metadata = pb_get_book_information();?>
 	<div class="log-wrap">	<!-- Login/Logout -->
@@ -13,55 +13,93 @@
 				<?php endif; ?>
 	    	<?php endif; ?>
 	    <?php endif; ?>
-	</div>   
-						
+	</div>
+
 			<div class="book-info">
 				<!-- Book Title -->
 				<h1 class="entry-title"><a href="<?php echo home_url( '/' ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
-				
+
 				<?php if ( ! empty( $metadata['pb_author'] ) ): ?>
 				<p class="book-author vcard author"><span class="fn"><?php echo $metadata['pb_author']; ?></span></p>
 			     	<span class="stroke"></span>
 				<?php endif; ?>
-				
+
 				<?php if ( ! empty( $metadata['pb_contributing_authors'] ) ): ?>
 					<p class="book-author"><?= $metadata['pb_contributing_authors']; ?> </p>
 				<?php endif; ?>
-					
+
 				<?php if ( ! empty( $metadata['pb_about_140'] ) ) : ?>
 					<p class="sub-title"><?php echo $metadata['pb_about_140']; ?></p>
 					<span class="detail"></span>
-				<?php endif; ?>						
-				
+				<?php endif; ?>
+
 				<?php if ( ! empty( $metadata['pb_about_50'] ) ): ?>
 					<p><?php echo pb_decode( $metadata['pb_about_50'] ); ?></p>
 				<?php endif; ?>
-		
+
 			</div> <!-- end .book-info -->
-			
+
 				<?php if ( ! empty( $metadata['pb_cover_image'] ) ): ?>
 				<div class="book-cover">
-				
+
 						<img src="<?php echo $metadata['pb_cover_image']; ?>" alt="book-cover" title="<?php bloginfo( 'name' ); ?> book cover" />
-					
-				</div>	
+
+				</div>
 				<?php endif; ?>
-				
+
 				<div class="call-to-action-wrap">
 					<?php global $first_chapter; ?>
 					<div class="call-to-action">
 						<a class="btn red" href="<?php global $first_chapter; echo $first_chapter; ?>"><span class="read-icon"></span><?php _e('Read', 'pressbooks'); ?></a>
-						
+
 						<?php if ( @array_filter( get_option( 'pressbooks_ecommerce_links' ) ) ) : ?>
 						 <!-- Buy -->
-							 <a class="btn black" href="<?php echo get_option('home'); ?>/buy"><span class="buy-icon"></span><?php _e('Buy', 'pressbooks'); ?></a>				
-						 <?php endif; ?>	
-						 
-						
-					</div> <!-- end .call-to-action -->		
+							 <a class="btn black" href="<?php echo get_option('home'); ?>/buy"><span class="buy-icon"></span><?php _e('Buy', 'pressbooks'); ?></a>
+						 <?php endif; ?>
+
+						<!-- display links to files -->
+						<?php
+						$files = \PBT\Utility\latest_exports();
+						$options = get_option( 'pbt_redistribute_settings' );
+						if ( is_array( $files ) && ( true == $options['latest_files_public'] ) ) {
+							echo '<div class="alt-formats">'
+							. '<h4>or freely download in these formats</h4>';
+
+							$dir = \PressBooks\Export\Export::getExportFolder();
+							foreach ( $files as $ext => $filename ) {
+								$file_extension = substr( strrchr( $ext, '.' ), 1 );
+								$pre_suffix = (false == strstr( $ext, '._3.epub' )) ? strstr( $ext, '._vanilla.xml') : strstr( $ext, '._3.epub' );
+
+								switch ( $file_extension ) {
+									case 'html':
+										$file_class = 'xhtml';
+										break;
+									case 'xml':
+										$file_class = ( false == $pre_suffix) ? 'wxr' : 'vanillawxr';
+										break;
+									case 'epub':
+										$file_class =  ( false  == $pre_suffix ) ? 'epub' : 'epub3';
+										break;
+									default:
+										$file_class = $file_extension;
+										break;
+								}
+
+								$filename = strstr( $filename, '.', true );
+
+								// rewrite rule
+								$url = "open/download?filename={$filename}&type={$file_class}";
+								echo '<link itemprop="bookFormat" href="http://schema.org/EBook">'
+									. '<a rel="nofollow" itemprop="offers" itemscope itemtype="http://schema.org/Offer" href="' . $url . '">'
+									. '<span class="export-file-icon small ' . $file_class . '" title="' . esc_attr( $filename ) . '"></span>'
+									. '<meta itemprop="price" content="$0.00"><link itemprop="availability" href="http://schema.org/InStock"></a>';
+							}
+							// end .alt-formats
+							echo "</div";
+						}
+						?>
+
+
+					</div> <!-- end .call-to-action -->
 				</div><!--  end .call-to-action-wrap -->
-				
-			
-			
-			
 	</section> <!-- end .top-block -->


### PR DESCRIPTION
Brad -- I'm suggesting a change in the visual appearance to make the reading options more coherent.

Currently, the "Read" button is separate from the downloadable options that appear further below, and the distance between these confuses my readers.

To make this more coherent, I suggest changing the button text to "Read Online," immediately followed by the the optional downloadable formats. See attached screenshot and my partial code revision. I don't have sufficient skills to rewrite the CSS properly.  Hope that helps.   -Jack

![whda_on_pressbookstest___simple_book_production](https://cloud.githubusercontent.com/assets/649719/4696296/3ff4b934-57eb-11e4-99b9-8beaa7a8579f.png)
