### PR TITLE
adding a min-width 50% for tables in MCE editor ..

### DIFF
--- a/symbionts/mce-textbook-buttons/assets/css/editor-style.css
+++ b/symbionts/mce-textbook-buttons/assets/css/editor-style.css
@@ -47,3 +47,7 @@
     padding-top: 15px;
     text-align: center;
 }
+
+table {
+    min-width: 50%;
+}


### PR DESCRIPTION
i've added: `table  {min-width: 50%;}`  in the MCE editor CSS ...

this means when you use the MCE Table Editor to insert a "blank" table, the resulting empty table in the Visual editor is no longer squished beyond recognition, and is something that a user can see & understand (ie: "oh, I fill in these squares now").