### PR TITLE
Separate superscript/subscript buttons and prepare for migration to Pressbooks

### DIFF
--- a/pressbooks-textbook.php
+++ b/pressbooks-textbook.php
@@ -121,6 +121,8 @@ class Textbook {
 		$pbt_plugin = array(
 		    'mce-table-buttons/mce_table_buttons.php' => 1,
 		    'mce-textbook-buttons/mce-textbook-buttons.php' => 1,
+		    'mce-anchor-button/mce-anchor-button.php' => 1,
+		    'mce-superscript-subscript-buttons/mce-superscript-subscript-buttons.php' => 1,
 		    'creative-commons-configurator-1/cc-configurator.php' => 1,
 		    'hypothesis/hypothesis.php' => 1,
 		    'tinymce-spellcheck/tinymce-spellcheck.php' => 1,
@@ -152,11 +154,18 @@ class Textbook {
 			if ( version_compare( PB_PLUGIN_VERSION, '2.5.1' ) >= 0 ) {
 				unset( $pbt_plugin['mce-table-buttons/mce_table_buttons.php'] );
 			}
+			if ( version_compare( PB_PLUGIN_VERSION, '2.5.2' ) >= 0 ) {
+				unset( $pbt_plugin['mce-anchor-button/mce-anchor-button.php'] );
+				unset( $pbt_plugin['mce-superscript-subscript-buttons/mce-superscript-subscript-buttons.php'] );
+			}
 		}
 		
 		// activate only if one of our themes is being used
 		if ( false == self::isTextbookTheme() ) {
+			unset( $pbt_plugin['mce-table-buttons/mce_table_buttons.php'] );
 			unset( $pbt_plugin['mce-textbook-buttons/mce-textbook-buttons.php'] );
+			unset( $pbt_plugin['mce-anchor-button/mce-anchor-button.php'] );
+			unset( $pbt_plugin['mce-superscript-subscript-buttons/mce-superscript-subscript-buttons.php'] );
 			unset( $pbt_plugin['hypothesis/hypothesis.php'] );
 			unset( $pbt_plugin['creative-commons-configurator-1/cc-configurator.php'] );
 			unset( $pbt_plugin['mce-table-buttons/mce_table_buttons.php'] );

--- a/pressbooks-textbook.php
+++ b/pressbooks-textbook.php
@@ -155,7 +155,6 @@ class Textbook {
 				unset( $pbt_plugin['mce-table-buttons/mce_table_buttons.php'] );
 			}
 			if ( version_compare( PB_PLUGIN_VERSION, '2.5.2' ) >= 0 ) {
-				unset( $pbt_plugin['mce-anchor-button/mce-anchor-button.php'] );
 				unset( $pbt_plugin['mce-superscript-subscript-buttons/mce-superscript-subscript-buttons.php'] );
 			}
 		}

--- a/symbionts/mce-anchor-button/assets/js/anchor.js
+++ b/symbionts/mce-anchor-button/assets/js/anchor.js
@@ -1,0 +1,41 @@
+/**
+ * plugin.js
+ *
+ * Copyright, Moxiecode Systems AB
+ * Released under LGPL License.
+ *
+ * License: http://www.tinymce.com/license
+ * Contributing: http://www.tinymce.com/contributing
+ */
+
+/*global tinymce:true */
+
+tinymce.PluginManager.add('anchor', function(editor) {
+	function showDialog() {
+		var selectedNode = editor.selection.getNode();
+
+		editor.windowManager.open({
+			title: 'Anchor',
+			body: {type: 'textbox', name: 'name', size: 40, label: 'Name', value: selectedNode.name || selectedNode.id},
+			onsubmit: function(e) {
+				editor.execCommand('mceInsertContent', false, editor.dom.createHTML('a', {
+					id: e.data.name
+				}));
+			}
+		});
+	}
+
+	editor.addButton('anchor', {
+		icon: 'anchor',
+		tooltip: 'Anchor',
+		onclick: showDialog,
+		stateSelector: 'a:not([href])'
+	});
+
+	editor.addMenuItem('anchor', {
+		icon: 'anchor',
+		text: 'Anchor',
+		context: 'insert',
+		onclick: showDialog
+	});
+});

--- a/symbionts/mce-anchor-button/mce-anchor-button.php
+++ b/symbionts/mce-anchor-button/mce-anchor-button.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Anchor Button
+ *
+ * @package   PressBooks_Textbook
+ * @author    Brad Payne <brad@bradpayne.ca>
+ * @license   GPL-2.0+
+ * @copyright 2014 Brad Payne
+ *
+ * @wordpress-plugin
+ * Plugin Name:       MCE Anchor Button for PressBooks
+ * Description:       Adds a button to TinyMCE for an anchor element in PressBooks
+ * Version:           1.0.0
+ * Author:            Brad Payne
+ * Text Domain:       mce-anchor-button
+ * License:           GPL-2.0+
+ * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
+
+ */
+
+namespace PBT\Plugins;
+
+class AnchorButton {
+
+	function __construct() {
+		// Define plugin constants
+		
+		// Load translations
+
+		// Hook in our bits
+		add_action( 'admin_init', array( $this, 'addFilters' ) );
+	}
+
+	function addFilters() {
+		
+		if ( ! current_user_can( 'edit_posts' ) && ! current_user_can( 'edit_pages' ) ) {
+			return;
+		}
+
+		if ( get_user_option( 'rich_editing' ) == 'true' ) {
+			add_filter( 'mce_external_plugins', array( $this, 'addAnchorButton' ) );
+			add_filter( 'mce_buttons_3', array( $this, 'registerAnchorButton' ) );
+		}
+	}
+
+	/**
+	 * Add the script to the mce array
+	 * 
+	 * @param array $plugin_array	
+	 * @return array
+	 */
+	function addAnchorButton( $plugin_array ) {
+
+		$plugin_array['anchor'] = PBT_PLUGIN_URL . 'symbionts/mce-textbook-buttons/assets/js/anchor.js';
+		return $plugin_array;
+	}
+
+	/**
+	 * Push our button onto the button stack in the 3rd mce row
+	 * 
+	 * @param type $buttons
+	 */
+	function registerAnchorButton( $buttons ) {
+
+		array_push( $buttons, 'anchor' );
+		return $buttons;
+	}
+	
+	}
+
+$anchor_button = new \PBT\Plugins\AnchorButton();
+

--- a/symbionts/mce-anchor-button/mce-anchor-button.php
+++ b/symbionts/mce-anchor-button/mce-anchor-button.php
@@ -1,22 +1,23 @@
 <?php
 
 /**
- * Anchor Button
+ * MCE Anchor Button for Pressbooks
  *
- * @package   PressBooks_Textbook
- * @author    Brad Payne <brad@bradpayne.ca>
- * @license   GPL-2.0+
- * @copyright 2014 Brad Payne
+ * @package			Pressbooks
+ * @author			Pressbooks <code@pressbooks.com>
+ * @contributors	Brad Payne <brad@bradpayne.ca>
+ * @license			GPLv2
+ * @copyright		2015 BookOven Inc.
  *
  * @wordpress-plugin
- * Plugin Name:       MCE Anchor Button for PressBooks
- * Description:       Adds a button to TinyMCE for an anchor element in PressBooks
- * Version:           1.0.0
- * Author:            Brad Payne
- * Text Domain:       mce-anchor-button
- * License:           GPL-2.0+
- * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
-
+ * Plugin Name:		MCE Anchor Button for Pressbooks
+ * Description:		Adds a button to TinyMCE for an anchor element in Pressbooks
+ * Version:			1.0.0
+ * Author:			BookOven Inc.
+ * Author URI:		http://www.pressbooks.com
+ * Text Domain:		pressbooks-mce-anchor-button
+ * License:			GPLv2
+ * License URI:		http://www.gnu.org/licenses/gpl-2.0.html
  */
 
 namespace PBT\Plugins;

--- a/symbionts/mce-superscript-subscript-buttons/mce-superscript-subscript-buttons.php
+++ b/symbionts/mce-superscript-subscript-buttons/mce-superscript-subscript-buttons.php
@@ -1,22 +1,23 @@
 <?php
 
 /**
- * Superscript & Subscript Buttons
+ * MCE Superscript & Subscript Buttons for Pressbooks
  *
- * @package   PressBooks_Textbook
- * @author    Brad Payne <brad@bradpayne.ca>
- * @license   GPL-2.0+
- * @copyright 2014 Brad Payne
+ * @package			Pressbooks
+ * @author			Pressbooks <code@pressbooks.com>
+ * @contributors	Brad Payne <brad@bradpayne.ca>
+ * @license			GPLv2
+ * @copyright		2015 BookOven Inc.
  *
  * @wordpress-plugin
- * Plugin Name:       MCE Superscript & Subscript Buttons for PressBooks
- * Description:       Adds buttons to TinyMCE for superscript and subscript elements in PressBooks
- * Version:           1.0.0
- * Author:            Brad Payne
- * Text Domain:       mce-superscript-subscript-buttons
- * License:           GPL-2.0+
- * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
-
+ * Plugin Name:		MCE Superscript & Subscript Buttons for Pressbooks
+ * Description:		Adds buttons to TinyMCE for superscript and subscript elements in Pressbooks
+ * Version:			1.0.0
+ * Author:			BookOven Inc.
+ * Author URI:		http://www.pressbooks.com
+ * Text Domain:		pressbooks-mce-superscript-subscript-buttons
+ * License:			GPLv2
+ * License URI:		http://www.gnu.org/licenses/gpl-2.0.html
  */
 
 namespace PBT\Plugins;

--- a/symbionts/mce-superscript-subscript-buttons/mce-superscript-subscript-buttons.php
+++ b/symbionts/mce-superscript-subscript-buttons/mce-superscript-subscript-buttons.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Superscript & Subscript Buttons
+ *
+ * @package   PressBooks_Textbook
+ * @author    Brad Payne <brad@bradpayne.ca>
+ * @license   GPL-2.0+
+ * @copyright 2014 Brad Payne
+ *
+ * @wordpress-plugin
+ * Plugin Name:       MCE Superscript & Subscript Buttons for PressBooks
+ * Description:       Adds buttons to TinyMCE for superscript and subscript elements in PressBooks
+ * Version:           1.0.0
+ * Author:            Brad Payne
+ * Text Domain:       mce-superscript-subscript-buttons
+ * License:           GPL-2.0+
+ * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
+
+ */
+
+namespace PBT\Plugins;
+
+class SuperscriptSubscriptButtons {
+
+	function __construct() {
+		// Define plugin constants
+		
+		// Load translations
+
+		// Hook in our bits
+		add_action( 'admin_init', array( $this, 'addFilters' ) );
+	}
+
+	function addFilters() {
+		
+		if ( ! current_user_can( 'edit_posts' ) && ! current_user_can( 'edit_pages' ) ) {
+			return;
+		}
+
+		if ( get_user_option( 'rich_editing' ) == 'true' ) {
+			add_filter( 'mce_buttons_3', array( $this, 'registerSuperscriptSubscriptButtons' ) );
+		}
+	}
+
+	/**
+	 * Push our buttons onto the buttons stack in the 3rd mce row
+	 * 
+	 * @param type $buttons
+	 */
+	function registerSuperscriptSubscriptButtons( $buttons ) {
+
+		array_push( $buttons, 'superscript', 'subscript' );
+		return $buttons;
+	}
+	
+	}
+
+$superscript_subscript_buttons = new \PBT\Plugins\SuperscriptSubscriptButtons();
+

--- a/symbionts/mce-textbook-buttons/mce-textbook-buttons.php
+++ b/symbionts/mce-textbook-buttons/mce-textbook-buttons.php
@@ -54,7 +54,6 @@ class TextbookButtons {
 	function addTextbookButtons( $plugin_array ) {
 
 		$plugin_array['textbookbuttons'] = PBT_PLUGIN_URL . 'symbionts/mce-textbook-buttons/assets/js/textbook-buttons.js';
-		$plugin_array['anchor'] = PBT_PLUGIN_URL . 'symbionts/mce-textbook-buttons/assets/js/anchor.js';
 		return $plugin_array;
 	}
 
@@ -65,7 +64,7 @@ class TextbookButtons {
 	 */
 	function registerTBButtons( $buttons ) {
 
-		array_push( $buttons, 'learningObjectives', 'keyTakeaway', 'exercises', 'anchor', 'superscript', 'subscript' );
+		array_push( $buttons, 'learningObjectives', 'keyTakeaway', 'exercises' );
 		return $buttons;
 	}
 

--- a/symbionts/mce-textbook-buttons/mce-textbook-buttons.php
+++ b/symbionts/mce-textbook-buttons/mce-textbook-buttons.php
@@ -1,22 +1,23 @@
 <?php
 
 /**
- * Textbook Buttons
+ * MCE Textbook Buttons for Pressbooks
  *
- * @package   PressBooks_Textbook
- * @author    Brad Payne <brad@bradpayne.ca>
- * @license   GPL-2.0+
- * @copyright 2014 Brad Payne
+ * @package			Pressbooks
+ * @author			Pressbooks <code@pressbooks.com>
+ * @contributors	Brad Payne <brad@bradpayne.ca>
+ * @license			GPLv2
+ * @copyright		2015 BookOven Inc.
  *
  * @wordpress-plugin
- * Plugin Name:       MCE Textbook Buttons for PressBooks
- * Description:       Adds buttons to TinyMCE for textbook specific sytles in PressBooks
- * Version:           1.0.0
- * Author:            Brad Payne
- * Text Domain:       mce-textbook-buttons
- * License:           GPL-2.0+
- * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
-
+ * Plugin Name:		MCE Anchor Button for Pressbooks
+ * Description:		Adds buttons to TinyMCE for textbook-specific styles in PressBooks
+ * Version:			1.0.0
+ * Author:			BookOven Inc.
+ * Author URI:		http://www.pressbooks.com
+ * Text Domain:		pressbooks-mce-textbook-buttons
+ * License:			GPLv2
+ * License URI:		http://www.gnu.org/licenses/gpl-2.0.html
  */
 
 namespace PBT\Plugins;


### PR DESCRIPTION
Hi @bdolor & co! As per https://github.com/pressbooks/pressbooks/issues/157, I am submitting this pull request which:

1. Separates the MCE Textbook Buttons plugin in `/symbionts` so we can selectively migrate the superscript/subscript buttons, the anchor button and the textbook block element buttons into Pressbooks core.
2. Conditionally unsets the new superscript/subscript button plugin when Textbook is installed on an instance of the forthcoming Pressbooks 2.5.2, which will include it. Please let me know if you'd like me to make any changes to this prior to merge.