### PR TITLE
New admin interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-PressBooks Textbook
+Pressbooks Textbook
 ===================
 
-A plugin that extends PressBooks for textbook authoring.
+A plugin that extends Pressbooks for textbook authoring.
 
-[PressBooks](https://github.com/pressbooks/pressbooks) is a content management and 'one button publishing' system for books.
+[Pressbooks](https://github.com/pressbooks/pressbooks) is a content management and 'one button publishing' system for books.
 
-**PressBooks Textbook** adds functionality to PressBooks to make it easier to author textbooks as well. The features it currently offers are: 
+**Pressbooks Textbook** adds functionality to Pressbooks to make it easier to author textbooks as well. The features it currently offers are: 
 * Textbook Theme
 * TinyMCE buttons: tables, spell check, anchor, super/subscript
 * TinyMCE textbook specific buttons (learning objectives, key terms, exercises)
@@ -15,7 +15,7 @@ A plugin that extends PressBooks for textbook authoring.
 * Annotation features
 * Optionally redistributing free, electronic versions of your book
 * Download links to openly licensed textbooks, ready to remix.
-* A remix 'eco-system' — Search and Import chapters from the same instance of PressBooks
+* A remix 'eco-system' — Search and Import chapters from the same instance of Pressbooks
 * Disable/enable comments
 
 Primary Use Case

--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-=== PressBooks Textbook ===
+=== Pressbooks Textbook ===
 Contributors: bdolor
 Donation link: https://github.com/BCcampus/pressbooks-textbook/wiki/Contribution-guidelines
 Tags: pressbooks, textbook
@@ -8,10 +8,10 @@ Stable tag: 1.2.15
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-PressBooks Textbook adds functionality to the PressBooks plugin to make it easier to author textbooks.
+Pressbooks Textbook adds functionality to the Pressbooks plugin to make it easier to author textbooks.
 
 == Description ==
-**PressBooks Textbook** adds functionality to PressBooks to make it easier to author textbooks as well. The features it currently offers are: 
+**Pressbooks Textbook** adds functionality to Pressbooks to make it easier to author textbooks as well. The features it currently offers are: 
 
 * Textbook Theme
 * TinyMCE table buttons
@@ -24,7 +24,7 @@ PressBooks Textbook adds functionality to the PressBooks plugin to make it easie
 * Annotation functionality
 * Optionally redistributing free, digital versions of your book.
 * Download links to openly licensed textbooks, ready to remix.
-* A remix 'eco-system' — Search and Import chapters from both local and remote instances of PressBooks
+* A remix 'eco-system' — Search and Import chapters from both local and remote instances of Pressbooks
 * Disable/enable comments
 
 Textbooks have functional and styling considerations above and beyond regular books. Open textbooks are those that are licensed with a [creative commons license](http://creativecommons.org).
@@ -34,8 +34,8 @@ This plugin was built primarily to support the creation, remixing and distributi
 
 IMPORTANT! 
 
-You must first install [PressBooks](https://github.com/pressbooks/pressbooks). This plugin won't work without it.
-The PressBooks github repository is updated frequently. [Stay up to date](https://github.com/pressbooks/pressbooks/tree/master).
+You must first install [Pressbooks](https://github.com/pressbooks/pressbooks). This plugin won't work without it.
+The Pressbooks github repository is updated frequently. [Stay up to date](https://github.com/pressbooks/pressbooks/tree/master).
 
 Most of the functionality of this plugin, like search, textbook buttons and annotation are tied directly to the `Open Textbooks` theme. Network Activate the `Open Textbooks` 
 theme, then activate at the book level. You'll have access to those features and more. 
@@ -51,7 +51,7 @@ theme, then activate at the book level. You'll have access to those features and
 = OR, go to the WordPress Dashboard =
 
 1. Navigate to the Network Admin -> Plugins
-2. Search for 'PressBooks Textbook'
+2. Search for 'Pressbooks Textbook'
 3. Click 'Network Activate'
 4. Activate the `Open Textbooks` theme at the network level
 5. Activate the `Open Textbooks` theme at the book level.

--- a/admin/assets/css/menu.css
+++ b/admin/assets/css/menu.css
@@ -4,20 +4,6 @@
     Author     : bpayne
 */
 
-li.toplevel_page_pb_import a.toplevel_page_pb_import .wp-menu-image::before{
-	font-family: FontAwesome !important;
-	-webkit-font-smoothing: antialiased;
-	background: none;
-	content: '\f112' !important;
-}
-
-li.toplevel_page_pressbooks-textbook a.toplevel_page_pressbooks-textbook .wp-menu-image::before{
-	font-family: FontAwesome !important;
-	-webkit-font-smoothing: antialiased;
-	background: none;
-	content: '\f10a' !important;
-}
-
 div.wrap ul li a.btn-small{
 	width:16%;
 	text-decoration: none;

--- a/admin/class-pbt-textbook-admin.php
+++ b/admin/class-pbt-textbook-admin.php
@@ -3,7 +3,7 @@
 /**
  * Administrative functionality, settings/options
  *
- * @package   PressBooks_Textbook
+ * @package   Pressbooks_Textbook
  * @author    Brad Payne <brad@bradpayne.ca>
  * @license   GPL-2.0+
  * @copyright 2014 Brad Payne
@@ -49,16 +49,20 @@ class TextbookAdmin extends \PBT\Textbook {
 	 */
 	function adminMenuAdjuster() {
 		if ( \Pressbooks\Book::isBook() ) {
-			add_menu_page( __( 'Import', $this->plugin_slug ), __( 'Import', $this->plugin_slug ), 'edit_posts', 'pb_import', '\PressBooks\Admin\Laf\display_import', '', 15 );
-			add_options_page( __( 'PressBooks Textbook Settings', $this->plugin_slug ), __( 'PB Textbook', $this->plugin_slug ), 'manage_options', $this->plugin_slug . '-settings', array( $this, 'displayPluginAdminPage' ) );
-			add_menu_page( __( 'PressBooks Textbook', $this->plugin_slug ), __( 'PB Textbook', $this->plugin_slug ), 'edit_posts', $this->plugin_slug , array( $this, 'displayPBTPage' ), '', 64 );
+			add_menu_page( __( 'Import', $this->plugin_slug ), __( 'Import', $this->plugin_slug ), 'edit_posts', 'pb_import', '\PressBooks\Admin\Laf\display_import', 'dashicons-download', 15 );
+			add_options_page( __( 'Pressbooks Textbook Settings', $this->plugin_slug ), __( 'PB Textbook', $this->plugin_slug ), 'manage_options', $this->plugin_slug . '-settings', array( $this, 'displayPluginAdminPage' ) );
+			add_menu_page( __( 'Pressbooks Textbook', $this->plugin_slug ), __( 'PB Textbook', $this->plugin_slug ), 'edit_posts', $this->plugin_slug , array( $this, 'displayPBTPage' ), 'dashicons-tablet', 64 );
 			// check if the functionality we need is available
 			if ( class_exists('\PressBooks\Api_v1\Api') ){
 				add_submenu_page( $this->plugin_slug, __('Search and Import', $this->plugin_slug), __('Search and Import', $this->plugin_slug), 'edit_posts', 'api_search_import',array( $this, 'displayApiSearchPage' ), '', 65 );
 			}
-			add_submenu_page( $this->plugin_slug, __('Download Textbooks', $this->plugin_slug), __('Download Textbooks', $this->plugin_slug), 'edit_posts', 'download_textbooks',array( $this, 'displayDownloadTextbooks' ), '', 66 );
+			add_submenu_page( $this->plugin_slug, __('Download Textbooks', $this->plugin_slug), __('Download Textbooks', $this->plugin_slug), 'edit_posts', 'download_textbooks', array( $this, 'displayDownloadTextbooks' ), '', 66 );
 			add_menu_page( 'Plugins', 'Plugins', 'manage_network_plugins', 'plugins.php', '', 'dashicons-admin-plugins', 67 );
-			remove_menu_page( 'pb_sell' );
+			if ( version_compare( PB_PLUGIN_VERSION, '2.7' ) >= 0 ) {
+				remove_menu_page( 'pb_publish' );
+			} else {
+				remove_menu_page( 'pb_sell' );
+			}
 		}
 	}
 	
@@ -197,7 +201,7 @@ class TextbookAdmin extends \PBT\Textbook {
 		// $id, $title, $callback, $page(menu slug)
 		add_settings_section(
 			$section, 
-			'Manage Federated Network of PressBooks sites', 
+			'Manage Federated Network of Pressbooks sites', 
 			'\PBT\Settings\remix_section_callback', 
 			$page
 		);

--- a/admin/class-pbt-textbook-admin.php
+++ b/admin/class-pbt-textbook-admin.php
@@ -49,7 +49,7 @@ class TextbookAdmin extends \PBT\Textbook {
 	 */
 	function adminMenuAdjuster() {
 		if ( \Pressbooks\Book::isBook() ) {
-			add_menu_page( __( 'Import', $this->plugin_slug ), __( 'Import', $this->plugin_slug ), 'edit_posts', 'pb_import', '\PressBooks\Admin\Laf\display_import', 'dashicons-download', 15 );
+			add_menu_page( __( 'Import', $this->plugin_slug ), __( 'Import', $this->plugin_slug ), 'edit_posts', 'pb_import', '\PressBooks\Admin\Laf\display_import', 'dashicons-upload', 15 );
 			add_options_page( __( 'Pressbooks Textbook Settings', $this->plugin_slug ), __( 'PB Textbook', $this->plugin_slug ), 'manage_options', $this->plugin_slug . '-settings', array( $this, 'displayPluginAdminPage' ) );
 			add_menu_page( __( 'Pressbooks Textbook', $this->plugin_slug ), __( 'PB Textbook', $this->plugin_slug ), 'edit_posts', $this->plugin_slug , array( $this, 'displayPBTPage' ), 'dashicons-tablet', 64 );
 			// check if the functionality we need is available

--- a/admin/views/admin-settings.php
+++ b/admin/views/admin-settings.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Represents the view for PressBooks Textbook Options page.
+ * Represents the view for Pressbooks Textbook Options page.
  *
- * @package PressBooks_Textbook
+ * @package Pressbooks_Textbook
  * @author Brad Payne <brad@bradpayne.ca>
  * @license   GPL-2.0+
  * 
@@ -60,12 +60,12 @@
 				echo "<h3>Search, Import</h3>";
 				
 				if ( class_exists( '\PressBooks\Api_v1\Api') ){
-					echo "<p>Remixing starts with finding the right content. <a href='admin.php?page=api_search_import'>Search this instance of PressBooks for relevant content and import it into your book</a>.</p>";
+					echo "<p>Remixing starts with finding the right content. <a href='admin.php?page=api_search_import'>Search this instance of Pressbooks for relevant content and import it into your book</a>.</p>";
 					settings_fields( 'pbt_remix_settings' );
 					do_settings_sections( 'pbt_remix_settings' );
 					
 				} else {
-					echo "<p>You will need to <a href='https://github.com/pressbooks/pressbooks/commit/78a68c9cbba1ce3f5783215194921224558e83a2'>upgrade to a more recent version of PressBooks which contains the API</a>. The functionality of Search and Import depends on the API.";
+					echo "<p>You will need to <a href='https://github.com/pressbooks/pressbooks/commit/78a68c9cbba1ce3f5783215194921224558e83a2'>upgrade to a more recent version of Pressbooks which contains the API</a>. The functionality of Search and Import depends on the API.";
 				}
 				
 				break;

--- a/admin/views/api-search.php
+++ b/admin/views/api-search.php
@@ -4,7 +4,7 @@
  * the PB API. The user has the option of importing any relevant chapters 
  * returned by the search.
  *
- * @package PressBooks_Textbook
+ * @package Pressbooks_Textbook
  * @author Brad Payne <brad@bradpayne.ca>
  * @license   GPL-2.0+
  * 

--- a/admin/views/download-textbooks.php
+++ b/admin/views/download-textbooks.php
@@ -2,7 +2,7 @@
 /**
  * This admin page allows editors access to functionality that downloads textbooks. 
  *
- * @package PressBooks_Textbook
+ * @package Pressbooks_Textbook
  * @author Brad Payne <brad@bradpayne.ca>
  * @license   GPL-2.0+
  * 

--- a/admin/views/pbt-home.php
+++ b/admin/views/pbt-home.php
@@ -2,7 +2,7 @@
 /**
  * This admin home page describes the what and why of opentextbooks. 
  *
- * @package PressBooks_Textbook
+ * @package Pressbooks_Textbook
  * @author Brad Payne <brad@bradpayne.ca>
  * @license   GPL-2.0+
  * 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 	<?php
 	// temporary message to shift people over to the correct location
 	if ( current_user_can( 'manage_options' ) ) {
-		echo "<div class='updated'><p>Manage <a href='options-general.php?page=pressbooks-textbook-settings'>PressBooks Textbook settings</a>.</p></div>";
+		echo "<div class='updated'><p>Manage <a href='options-general.php?page=pressbooks-textbook-settings'>Pressbooks Textbook settings</a>.</p></div>";
 	}
 	?>
 	<h3>Why Open Textbooks?</h3>

--- a/includes/modules/catalogue/EquellaFetch.php
+++ b/includes/modules/catalogue/EquellaFetch.php
@@ -5,7 +5,7 @@
  * Equella comes with an overview of the REST API http://solr.bccampus.ca:8001/bcc/apidocs.do
  * October 2012
  * 
- * @package   PressBooks_Textbook
+ * @package   Pressbooks_Textbook
  * @author    Brad Payne <brad@bradpayne.ca>
  * @license   GPL-2.0+
  */

--- a/includes/modules/catalogue/Filter.php
+++ b/includes/modules/catalogue/Filter.php
@@ -4,7 +4,7 @@
  * Filter provides different views of the data. It takes arrays and turns them into html 
  * October 2012
  * 
- * @package   PressBooks_Textbook
+ * @package   Pressbooks_Textbook
  * @author    Brad Payne <brad@bradpayne.ca>
  * @license   GPL-2.0+
  */

--- a/includes/modules/import/class-pbt-pbimport.php
+++ b/includes/modules/import/class-pbt-pbimport.php
@@ -3,9 +3,9 @@
 /**
  * Uses the v1/API to search titles based on a user defined search term
  *
- * Provides an interface to turn an instance of PressBooks into a remix 'ecosystem' 
+ * Provides an interface to turn an instance of Pressbooks into a remix 'ecosystem' 
  *
- * @package PressBooks_Textbook
+ * @package Pressbooks_Textbook
  * @author Brad Payne <brad@bradpayne.ca>
  * @license   GPL-2.0+
  * 

--- a/includes/modules/import/class-pbt-remoteimport.php
+++ b/includes/modules/import/class-pbt-remoteimport.php
@@ -2,11 +2,11 @@
 
 /**
  * Uses the v1/API to search titles on a remote system based on a user defined search term
- * Extends the existing Xthml import class used in PressBooks, the only differences being that we 
+ * Extends the existing Xthml import class used in Pressbooks, the only differences being that we 
  * are sending that class more than one url/page to scrape at a time and we need to revoke 
  * the PBT import rather than the PB import.
  * 
- * @package PressBooks_Textbook
+ * @package Pressbooks_Textbook
  * @author Brad Payne <brad@bradpayne.ca>
  * @license GPL-2.0+
  * 

--- a/includes/modules/search/class-pbt-apisearch.php
+++ b/includes/modules/search/class-pbt-apisearch.php
@@ -3,7 +3,7 @@
 /**
  * Searches the API for resources, returns results to an import interface
  *
- * @package PressBooks_Textbook
+ * @package Pressbooks_Textbook
  * @author Brad Payne <brad@bradpayne.ca>
  * @license   GPL-2.0+
  * 
@@ -161,7 +161,7 @@ class ApiSearch {
 				$ok = $importer->import( $all_chapters );
 			}
 
-			$msg = "Tried to import a post from this PressBooks instance and ";
+			$msg = "Tried to import a post from this Pressbooks instance and ";
 			$msg .= ( $ok ) ? 'succeeded :)' : 'failed :(';
 
 			if ( $ok ) {
@@ -213,7 +213,7 @@ class ApiSearch {
 			$importer = new Import\RemoteImport();
 			$ok = $importer->import( $all_chapters );
 
-			$msg = "Tried to import a post from this PressBooks instance and ";
+			$msg = "Tried to import a post from this Pressbooks instance and ";
 			$msg .= ( $ok ) ? 'succeeded :)' : 'failed :(';
 
 			if ( $ok ) {

--- a/includes/pbt-rewrite.php
+++ b/includes/pbt-rewrite.php
@@ -3,7 +3,7 @@
 /**
  * Rewrite rules for file downloads.
  * *
- * @package PressBooks_Textbook
+ * @package Pressbooks_Textbook
  * @author Brad Payne <brad@bradpayne.ca>
  * @license   GPL-2.0+
  * 

--- a/includes/pbt-settings.php
+++ b/includes/pbt-settings.php
@@ -1,9 +1,9 @@
 <?php
 
 /**
- * Options/Settings for PressBooks Textbook plugin
+ * Options/Settings for Pressbooks Textbook plugin
  * 
- * @package PressBooks_Textbook
+ * @package Pressbooks_Textbook
  * @author Brad Payne <brad@bradpayne.ca>
  * @license   GPL-2.0+
  * 
@@ -39,7 +39,7 @@ function latest_files_public_callback( $args ) {
 	$html = '<input type="radio" id="files-public" name="pbt_redistribute_settings[latest_files_public]" value="1"' . checked( 1, $options['latest_files_public'], false ) . '/> ';
 	$html .= '<label for="files-public"> ' . __( 'Yes. I would like the latest export files to be available on the homepage for free, to everyone.', 'pressbooks-textbook' ) . '</label><br />';
 	$html .= '<input type="radio" id="files-admin" name="pbt_redistribute_settings[latest_files_public]" value="0" ' . checked( 0, $options['latest_files_public'], false ) . '/> ';
-	$html .= '<label for="files-admin"> ' . __( 'No. I would like the latest export files to only be available to administrators. (PressBooks default)', 'pressbooks-textbook' ) . '</label>';
+	$html .= '<label for="files-admin"> ' . __( 'No. I would like the latest export files to only be available to administrators. (Pressbooks default)', 'pressbooks-textbook' ) . '</label>';
 	echo $html;
 }
 
@@ -126,7 +126,7 @@ function pbt_reuse_section_callback() {
 		<li>XML - as part of post_metadata</li>"
 	. "</ul></li>"
 	. "<li>The license information is searchable; it contains machine readable metadata.</li>"
-	. "<li>The module is made specifically for PressBooks!</li>"
+	. "<li>The module is made specifically for Pressbooks!</li>"
 	. "<li>You can specify page license (if it is different than your book license). A page license can override the book license, in a similar fashion to a page author overriding the book author.</li>"
 	. "<li>It uses the <a target='_blank' href='https://api.creativecommons.org/docs/readme_15.html'>webservice API</a> that Creative Commons supplies.</li>"
 	. "<li>It comes with some language capabilities (depending on what Language you've defined in 'Book Info' and what the API supports.</li>"
@@ -184,7 +184,7 @@ function reuse_absint_sanitize( $input ) {
  * 
  */
 function remix_section_callback(){
-	echo "<p>If you know of another PressBooks instance, and you know they also have Creative Commons licensed materials, here is where you add their domain."
+	echo "<p>If you know of another Pressbooks instance, and you know they also have Creative Commons licensed materials, here is where you add their domain."
 	. " Having a list of domains will enable <a href='admin.php?page=api_search_import'>searching and importing</a> against their collection, the same way that you can search and import against your own collection.</p>";
 	
 } 
@@ -237,7 +237,7 @@ function remix_url_sanitize( $input ) {
 		// sanitize, reset the key to maintain sequential numbering, to account for blank entries
 		$valid['pbt_api_endpoints'][$i] = trailingslashit(esc_url( $url, $protocols )) ;
 
-		// check if they are API enabled PressBooks instances: 
+		// check if they are API enabled Pressbooks instances: 
 		$api_endpoint = $valid['pbt_api_endpoints'][$i] . 'api/v1/books/';
 
 		$check_response = wp_remote_head( $api_endpoint );

--- a/includes/pbt-utility.php
+++ b/includes/pbt-utility.php
@@ -2,7 +2,7 @@
 /**
  * Utility functions particular to PBT
  *
- * @package PressBooks_Textbook
+ * @package Pressbooks_Textbook
  * @author Brad Payne <brad@bradpayne.ca>
  * @license   GPL-2.0+
  * 

--- a/pressbooks-textbook.php
+++ b/pressbooks-textbook.php
@@ -1,16 +1,16 @@
 <?php
 
 /**
- * PressBooks Textbook
+ * Pressbooks Textbook
  *
- * @package   PressBooks_Textbook
+ * @package   Pressbooks_Textbook
  * @author    Brad Payne <brad@bradpayne.ca>
  * @license   GPL-2.0+
  * @copyright 2014 Brad Payne
  *
  * @wordpress-plugin
- * Plugin Name:       PressBooks Textbook
- * Description:       A plugin that extends PressBooks for textbook authoring
+ * Plugin Name:       Pressbooks Textbook
+ * Description:       A plugin that extends Pressbooks for textbook authoring
  * Version:           1.2.15
  * Author:            Brad Payne
  * Author URI:        http://bradpayne.ca		

--- a/symbionts/disable-comments/disable-comments.php
+++ b/symbionts/disable-comments/disable-comments.php
@@ -20,11 +20,11 @@
  * http://rayofsolaris.net/
  * https://github.com/solarissmoke/disable-comments
  * 
- * This fork modifies the plugin to work with PressBooks; strips unwanted features, adds others.
+ * This fork modifies the plugin to work with Pressbooks; strips unwanted features, adds others.
  * 
  * Designed to be activated only at the site level for site autonomy. Also gets rid of the atomic/permanently destructive 
  * comment disabling that the original plugin currently has. 
- * The default state is to disable the comments for the custom post types that PressBooks defines. 
+ * The default state is to disable the comments for the custom post types that Pressbooks defines. 
  * Requires the user to actively turn comments on if they want comments.
  *
  */
@@ -92,7 +92,7 @@ class Disable_Comments {
 		}
 		
 		// Not part of the original plugin
-		// Added for integration with PressBooks Textbook plugin
+		// Added for integration with Pressbooks Textbook plugin
 		// Sets defaults, disables comments on custom post types
 		$this->pbtModifyDisableComments();
 		
@@ -284,7 +284,7 @@ class Disable_Comments {
 				return;
 		$hascaps = current_user_can( 'manage_options' );
 		if ( $hascaps )
-				echo '<div class="updated fade"><p>' . sprintf( __( 'The <em>Disable Comments</em> plugin is active and configured to disable comments on custom post types for PressBooks. Visit the <a href="%s">configuration page</a> to choose which post types to <b>enable</b> comments on.', 'disable-comments' ), esc_attr( $this->settings_page_url() ) ) . '</p></div>';
+				echo '<div class="updated fade"><p>' . sprintf( __( 'The <em>Disable Comments</em> plugin is active and configured to disable comments on custom post types for Pressbooks. Visit the <a href="%s">configuration page</a> to choose which post types to <b>enable</b> comments on.', 'disable-comments' ), esc_attr( $this->settings_page_url() ) ) . '</p></div>';
 	}
 
 	/**
@@ -493,7 +493,7 @@ class Disable_Comments {
 
 	/**
 	 * Not part of the original plugin. 
-	 * Added for integration with PressBooks Textbook plugin
+	 * Added for integration with Pressbooks Textbook plugin
 	 */
 	private function pbtModifyDisableComments() {
 		$post_types = array( 'chapter', 'front-matter', 'back-matter', 'attachment' );

--- a/themes-book/opentextbook/footer.php
+++ b/themes-book/opentextbook/footer.php
@@ -60,7 +60,7 @@
 			if ( 'opentextbc.ca' == $_SERVER['SERVER_NAME'] ) {
 				_e( '<a href="http://open.bccampus.ca/find-open-textbooks/">This textbook is available for free at open.bccampus.ca</a>', 'pressbooks' );
 			} else {
-				_e('PressBooks.com: Simple Book Production', 'pressbooks');
+				_e('Pressbooks.com: Simple Book Production', 'pressbooks');
 			}
 			?>
 		</p>

--- a/themes-book/opentextbook/functions.php
+++ b/themes-book/opentextbook/functions.php
@@ -31,7 +31,7 @@ function pbt_get_seo_meta_elements() {
 	    'publisher' => 'pb_publisher'
 	);
 
-	$html = "<meta name='application-name' content='PressBooks'>\n";
+	$html = "<meta name='application-name' content='Pressbooks'>\n";
 	$metadata = \PressBooks\Book::getBookInformation();
 
 	// create meta elements

--- a/themes-book/opentextbook/page-cover-bottom-block.php
+++ b/themes-book/opentextbook/page-cover-bottom-block.php
@@ -23,9 +23,9 @@
 										$social_buttons = get_option( 'pressbooks_theme_options_web' );
 										if ( isset ( $social_buttons['social_media'] ) && 1 === $social_buttons['social_media'] || ! isset( $social_buttons['social_media'] ) ) {
 											?>
-											<div id="twitter" data-url="<?php the_permalink(); ?>" data-text="Check out this great book on PressBooks." data-title="Tweet"></div>
-											<div id="facebook" data-url="<?php the_permalink(); ?>" data-text="Check out this great book on PressBooks." data-title="Like"></div>
-											<div id="googleplus" data-url="<?php the_permalink(); ?>" data-text="Check out this great book on PressBooks." data-title="+1"></div>
+											<div id="twitter" data-url="<?php the_permalink(); ?>" data-text="Check out this great book on Pressbooks." data-title="Tweet"></div>
+											<div id="facebook" data-url="<?php the_permalink(); ?>" data-text="Check out this great book on Pressbooks." data-title="Like"></div>
+											<div id="googleplus" data-url="<?php the_permalink(); ?>" data-text="Check out this great book on Pressbooks." data-title="+1"></div>
 										<?php } ?>	
 									</div>	
 						</div>

--- a/themes-book/opentextbook/page-cover-top-block.php
+++ b/themes-book/opentextbook/page-cover-top-block.php
@@ -69,7 +69,7 @@
 					echo '<div class="alt-formats">'
 					. '<h4>Download in the following formats:</h4>';
 
-					$dir = \PressBooks\Export\Export::getExportFolder();
+					$dir = \Pressbooks\Export\Export::getExportFolder();
 					foreach ( $files as $ext => $filename ) {
 						$file_extension = substr( strrchr( $ext, '.' ), 1 );
 


### PR DESCRIPTION
Hi @bdolor, we've recently done a great deal of work on Pressbooks to clean up the admin interface (paving the way for the long promised Pressbooks Extras). This has included removing some old dependencies including Font Awesome, so this PR updates Pressbooks Textbook to use WordPress' built-in icon font instead. It also addresses a change to the Sell page, which will be the Publish page in the forthcoming Pressbooks 2.7. Lastly, we are no longer using camelcase (PressBooks -> Pressbooks) so I've updated instances of the old name where it was found in PB Textbook. Thanks in advance!