### PR TITLE
Update theme to use metacomponents for forward-compatibility

### DIFF
--- a/themes-book/opentextbook/assets/styles/components/_elements.scss
+++ b/themes-book/opentextbook/assets/styles/components/_elements.scss
@@ -175,14 +175,7 @@ $para-margin-bottom: 1em !default;
 @import 'variables/elements';
 
 // Add custom SCSS below these imports and includes.
-@import 'components/elements/links';
-@import 'components/elements/blockquotes';
-@import 'components/elements/body';
-@import 'components/elements/headings';
-@import 'components/elements/lists';
-@import 'components/elements/miscellaneous';
-@import 'components/elements/paragraphs';
-@import 'components/elements/tables';
+@import 'components/elements';
 
 // text custom
 $text-transform-upper: uppercase;

--- a/themes-book/opentextbook/assets/styles/components/_media.scss
+++ b/themes-book/opentextbook/assets/styles/components/_media.scss
@@ -44,9 +44,7 @@ $prince-image-resolution: 135dpi !default;
 @import 'variables/media';
 
 // Add custom SCSS below these imports and includes.
-@import 'components/media/images';
-@import 'components/media/audio';
-@import 'components/media/video';
+@import 'components/media';
 
 /*
 |--------------------------------------------------------------------------

--- a/themes-book/opentextbook/assets/styles/components/_pages.scss
+++ b/themes-book/opentextbook/assets/styles/components/_pages.scss
@@ -178,8 +178,4 @@ $epigraph-align: left !default;
 @import 'variables/pages';
 
 // Add custom SCSS below these imports and includes.
-@import 'components/pages/titles';
-@import 'components/pages/parts';
-@import 'components/pages/front-matter';
-@import 'components/pages/chapters';
-@import 'components/pages/back-matter';
+@import 'components/pages';

--- a/themes-book/opentextbook/assets/styles/components/_section-titles.scss
+++ b/themes-book/opentextbook/assets/styles/components/_section-titles.scss
@@ -157,10 +157,7 @@ $back-matter-title-align: left !default;
 @import 'variables/section-titles';
 
 // Add custom SCSS below these imports and includes.
-@import 'components/section-titles/parts';
-@import 'components/section-titles/front-matter';
-@import 'components/section-titles/chapters';
-@import 'components/section-titles/back-matter';
+@import 'components/section-titles';
 
 /*
 |--------------------------------------------------------------------------

--- a/themes-book/opentextbook/assets/styles/components/_specials.scss
+++ b/themes-book/opentextbook/assets/styles/components/_specials.scss
@@ -168,14 +168,7 @@ $textbox-font-size: 1em !default;
 @import 'variables/specials';
 
 // Add custom SCSS below these imports and includes.
-@import 'components/specials/columns';
-@import 'components/specials/dropcaps';
-@import 'components/specials/floats';
-@import 'components/specials/footnotes';
-@import 'components/specials/miscellaneous';
-@import 'components/specials/pullquotes';
-@import 'components/specials/separators';
-@import 'components/specials/textboxes';
+@import 'components/specials';
 
 /*
 |--------------------------------------------------------------------------

--- a/themes-book/opentextbook/assets/styles/components/_structure.scss
+++ b/themes-book/opentextbook/assets/styles/components/_structure.scss
@@ -155,8 +155,4 @@ $page-number-font-size: .7em !default;
 @import 'variables/structure';
 
 // Add custom SCSS below these imports and includes.
-@import 'components/structure/general';
-@import 'components/structure/recto-verso';
-@import 'components/structure/running-content';
-@import 'components/structure/numbering';
-@import 'components/structure/content-strings';
+@import 'components/structure';


### PR DESCRIPTION
As per my note the other day, this PR switches to using the metacomponent partials that will be available in the forthcoming Pressbooks Book 1.9. This will prevent future missing imports if we add new subcomponents within the main areas.