### PR TITLE
Added stylesheet enqueu for parent style sheet

### DIFF
--- a/themes-book/opentextbook/functions.php
+++ b/themes-book/opentextbook/functions.php
@@ -1,5 +1,20 @@
 <?php
 
+/** Enqueu Parent (pressbooks-books AKA Luther) Stylesheet **/
+
+function my_theme_enqueue_styles() {
+
+    $parent_style = 'pressbooks/book'; 
+
+    wp_enqueue_style( $parent_style, get_template_directory_uri() . '/style.css' );
+    wp_enqueue_style( 'child-style',
+        get_stylesheet_directory_uri() . '/style.css',
+        array( $parent_style ),
+        wp_get_theme()->get('Version')
+    );
+}
+add_action( 'wp_enqueue_scripts', 'my_theme_enqueue_styles' );
+
 /**
  * Returns an html blog of meta elements
  *


### PR DESCRIPTION
Having problems pulling in the Parent (pressbooks-books) style.css sheet.  When I added the enqueue script (from wordpress.org) it resulted in the normal CSS coming back to all my network.  I've been missing the css for the last several updates and I'm pretty sure I have a vanilla install.  

[http://librarywp.whatcom.edu/press/](http://librarywp.whatcom.edu/press/)

