### PR TITLE
Buckram 1.0 compatibility for Open Textbooks theme (fix #170)

### DIFF
--- a/themes-book/opentextbook/assets/styles/web/style.scss
+++ b/themes-book/opentextbook/assets/styles/web/style.scss
@@ -11,6 +11,5 @@ $type: 'web';
 @import '../components/tabs';
 @import '../components/pages';
 @import '../components/section-titles';
-@import '../components/toc';
 @import '../components/accessibility';
 @import '../components/mediaqueries';


### PR DESCRIPTION
This PR addresses issue #170, reported by @josiegray. The TOC component is not used in the webbook styles, and importing it now throws an error with Buckram >= 1.0, so I removed that import which appears to have fixed the issue in my testing.